### PR TITLE
added missing include file to address build issue

### DIFF
--- a/src/McCadIOTools/McCadInputModelData.cxx
+++ b/src/McCadIOTools/McCadInputModelData.cxx
@@ -7,6 +7,8 @@
 
 #include "../McCadTool/McCadConvertConfig.hxx"
 
+#include <unistd.h>
+
 McCadInputModelData::McCadInputModelData()
 {
     m_listModelData = new TopTools_HSequenceOfShape();


### PR DESCRIPTION
This PR introduces a missing header file that was causing issues in building McCAD against OCE-0.9.0. 